### PR TITLE
Background thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ http = "0.2.9"
 tokio = { version ="1.29.1", features = ["full"] }
 
 [dev-dependencies]
-reqwest = { version = "0.11.18", features = ["json"] }
+reqwest = { version = "0.11.18", features = ["json", "blocking"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,26 +23,35 @@ type Connectors = Arc<Mutex<HashMap<String, Connector>>>;
 
 impl KcTestServer {
     pub fn new() -> Self {
-        let (shutdown, rx) = tokio::sync::oneshot::channel::<()>();
+        let (tx, rx) = std::sync::mpsc::channel();
 
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        let app = Router::new()
-            .route("/connectors", get(list_connectors))
-            .route("/connectors", post(create_connector))
-            .with_state(Connectors::new(Mutex::new(
-                HashMap::<String, Connector>::new(),
-            )));
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            runtime.block_on(async {
+                let (shutdown, rx) = tokio::sync::oneshot::channel::<()>();
 
-        let server = axum::Server::from_tcp(listener)
-            .unwrap()
-            .serve(app.into_make_service())
-            .with_graceful_shutdown(async {
-                rx.await.ok();
+                let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+                let addr = listener.local_addr().unwrap();
+                let app = Router::new()
+                    .route("/connectors", get(list_connectors))
+                    .route("/connectors", post(create_connector))
+                    .with_state(Connectors::new(Mutex::new(
+                        HashMap::<String, Connector>::new(),
+                    )));
+
+                let server = axum::Server::from_tcp(listener)
+                    .unwrap()
+                    .serve(app.into_make_service())
+                    .with_graceful_shutdown(async {
+                        rx.await.ok();
+                    });
+                
+                tokio::spawn(server);
+                tx.send((addr, shutdown)).unwrap();
             });
+        });
 
-        tokio::spawn(server);
-
+        let (addr, shutdown) = rx.recv().unwrap();
         KcTestServer {
             addr,
             _shutdown: Some(shutdown),
@@ -346,17 +355,13 @@ mod tests {
         assert_eq!(response, "[\"sink-connector\"]");
     }
 
-    #[tokio::test]
-    async fn test_listing_empty_connectors() {
+    // #[tokio::test]
+    #[test]
+    fn test_listing_empty_connectors() {
         let server = KcTestServer::new();
         let endpoint = format!("{}{}", server.base_url().to_string(), "connectors");
         let reqwest_uri = reqwest::Url::from_str(&endpoint).unwrap();
-        let response = reqwest::get(reqwest_uri)
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
+        let response = reqwest::blocking::get(reqwest_uri).unwrap().text().unwrap();
         assert_eq!(response, "[]");
     }
 


### PR DESCRIPTION
This PR makes spawning a new server in a background thread instead of a the context of an async runtime in the main thread. This makes calling code does not need to be async or does not need to block.